### PR TITLE
Add URL table to isolate differences in similar URLs

### DIFF
--- a/survey/TODO
+++ b/survey/TODO
@@ -2,21 +2,27 @@ TODO for final project
 ================================================================================
 Process.py
 --------------------------------------------------------------------------------
-	- Want a way to sort similar URLs that have one or more different part
-	  Perhaps a fine-grained splitting of URLs? Look for sets that share
-	  almost all elements, separate out the different parts
-	  - Would involve splitting the netloc by '.', path by '/', params by ';'
-	    query by '&', fragment by something else
+
+Urltable.py
+--------------------------------------------------------------------------------
 	  - Looks like there can also be queries or params in other parts of the
 	    URL... So have to do splitting within each section
-          - Want to keep split parts in order
 	  - Perhaps allow a customizable "similarity threshold", meaning a number
 	    of differences to tolerate before considreing something a separate URL
 	    or could there be a way of determining this dynamically?
-	  - Some URLs have other URLs within them, as part of the query for instance
-	  - URLs that are split into different length lists would automatically be
-	    considered non-similar
-	  - Data structure implementation: a list of lists of dictionaries	
-	  - Additional assumption: all URLs that could possibly be considered similar
-	    will be grouped together
+	    - Need to improve the similarity threshold; some URLs have a ton of params
+	      that are different but are fundamentally the same but can't lower sim
+	      threshold universally; perhaps weight different segments higher?
+	    - For example, if all netloc segments and path same, URLs very likely 
+	      should be considered similar
+	  - There is additional splitting that should be done; examples:
+	    - amazon.com, https://pixel.adsafeprotected.com... commas within query
+	      javascript? param is called "jsinfo"
+	    - At the same time, there are sometimes unique comma-separated lists of 
+	      numbers as param values; necessarily want to split those
+
+Urltrie.py
+--------------------------------------------------------------------------------
+	    
+
 

--- a/survey/TODO
+++ b/survey/TODO
@@ -1,0 +1,22 @@
+TODO for final project
+================================================================================
+Process.py
+--------------------------------------------------------------------------------
+	- Want a way to sort similar URLs that have one or more different part
+	  Perhaps a fine-grained splitting of URLs? Look for sets that share
+	  almost all elements, separate out the different parts
+	  - Would involve splitting the netloc by '.', path by '/', params by ';'
+	    query by '&', fragment by something else
+	  - Looks like there can also be queries or params in other parts of the
+	    URL... So have to do splitting within each section
+          - Want to keep split parts in order
+	  - Perhaps allow a customizable "similarity threshold", meaning a number
+	    of differences to tolerate before considreing something a separate URL
+	    or could there be a way of determining this dynamically?
+	  - Some URLs have other URLs within them, as part of the query for instance
+	  - URLs that are split into different length lists would automatically be
+	    considered non-similar
+	  - Data structure implementation: a list of lists of dictionaries	
+	  - Additional assumption: all URLs that could possibly be considered similar
+	    will be grouped together
+

--- a/survey/dprocess.sh
+++ b/survey/dprocess.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for hostdir in results/*; do
+    targets=$(find $hostdir -name "results.json")
+    outfile="resultstats/"$hostdir"-detailed.txt"
+    echo "processing "$hostdir"..."
+    python process.py $targets > $outfile
+done

--- a/survey/dprocess.sh
+++ b/survey/dprocess.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 for hostdir in results/*; do
     targets=$(find $hostdir -name "results.json")
-    outfile="resultstats/"$hostdir"-detailed.txt"
+    re="results/(.*)"
+    if [[ $hostdir =~ $re ]]
+    then
+	outfile="resultstats/"${BASH_REMATCH[1]}"-detailed.txt"
+    else
+	echo "Script error; can't extract output directory name"
+    fi
     echo "processing "$hostdir"..."
     python process.py $targets > $outfile
 done

--- a/survey/helper.py
+++ b/survey/helper.py
@@ -1,0 +1,18 @@
+# Some basic helper functions
+
+import sys
+
+def remove_empty_strings(l):
+    return filter(lambda elt: elt != '', l)
+
+# Strip takes an index and a list of tuples of the same size
+# and returns a list of elements corresponding to the element
+# found at index i in every tuple in the list
+def strip(tuple_list,i):
+    if len(tuple_list) == 0:
+        print "warning: can't strip empty list"
+    assert i < len(tuple_list[0])
+    strip_list = []
+    for t in tuple_list:
+        strip_list.append(t[i])
+    return strip_list

--- a/survey/process.py
+++ b/survey/process.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+import urltrie
 
 def jaccard(sets):
 	if len(sets) == 0:
@@ -19,35 +20,88 @@ def jaccard(sets):
 		return 0.0
 	return len(intersection) / float(len(union))
 
-fail_count = 0
-hash_sets = []
-url_sets = []
+def process_main(sys_args):
+	n_trials = len(sys_args)-1
+	fail_count = 0
 
-# Iterate over all of the runs for a given URL.
-# We're particularly interested in whether they
-# saw different URLs or different contents at
-# the same URL. Computes the Jaccard similarities
-# for both.
-if len(sys.argv) < 2:
-	print 'Usage: python process.py dir'
-	exit()
+	# List of Hash sets
+	# Each resource is associated with a hash, each attempt with a set of resource hashes
+	hash_sets = []
+	
+	# List of URL sets
+	# Each successful attempt is associated with a set of resource URLs
+	url_sets = []
 
-for target in sys.argv[1:]:
-	host = target.split('/')[1]
-	with open(target) as data_file:
-		results = json.load(data_file)
-		assert results['url'] == host
+	# Dictionary mapping each URL to the number of occurrences
+	# For a site that returns exactly the same resources with every attempt,
+	# the number of occurrences for all URLs should be constant
+	url_occ_dict = {}
 
-		if results['status'] != 'success':
-			fail_count += 1
-			continue
+	# Iterate over all of the runs for a given URL.
+	# We're particularly interested in whether they
+	# saw different URLs or different contents at
+	# the same URL. Computes the Jaccard similarities
+	# for both.
+	for target in sys_args[1:]:
+		host = target.split('/')[1]
+		with open(target) as data_file:
+			results = json.load(data_file)
+			assert results['url'] == host
+			
+			if results['status'] != 'success':
+				fail_count += 1
+				continue
+			
+			res = results['resources']
+			urls = [r['url'] for r in res]
+			url_occ_dict = update_url_occurrences(url_occ_dict, urls)
+			url_sets.append(set(urls))
+			
+			hashes = [r['hash'] for r in res]
+			hash_sets.append(set(hashes))
+				
+	fmt = '%24s: urls=%.3f hashes=%.3f fails=%02d'
+	print fmt % (host, jaccard(url_sets), jaccard(hash_sets), fail_count)
+	inconsistent_url_dict = extract_inconsistent_urls(url_occ_dict,n_trials)
+	parse_urls(inconsistent_url_dict.keys())
+	
 
-		res = results['resources']
-		urls = [r['url'] for r in res]
-		url_sets.append(set(urls))
+# Write a function to compare URL sets acquired from different targets
+def update_url_occurrences(url_occ_dict, urls):
+	for url in urls:
+		if url in url_occ_dict:
+			url_occ_dict[url] += 1
+		else:
+			url_occ_dict[url] = 1
+	return url_occ_dict
 
-		hashes = [r['hash'] for r in res]
-		hash_sets.append(set(hashes))
+def print_dict(d):
+	for k,v in d.items():
+		print k, ": ", v
 
-fmt = '%24s: urls=%.3f hashes=%.3f fails=%02d'
-print fmt % (host, jaccard(url_sets), jaccard(hash_sets), fail_count)
+def extract_inconsistent_urls(url_occ_dict, n_trials):
+	inconsistent_url_dict = {}
+	for url in sorted(url_occ_dict.keys()):
+		url_occs = url_occ_dict[url]
+		assert url_occs <= n_trials
+		if url_occ_dict[url] < n_trials:
+			inconsistent_url_dict[url] = url_occs
+	return inconsistent_url_dict
+			
+
+def parse_urls(url_list):
+	url_trie = {}
+	for url in url_list:
+		url_trie = urltrie.insert_url(url,url_trie)
+	urltrie.print_trie(url_trie,0)
+
+def main():
+	if len(sys.argv) < 2:
+		print 'Usage: python process.py dir'
+		exit()
+	sys_args = sys.argv
+
+	process_main(sys_args)
+
+if __name__ == '__main__':
+	main()

--- a/survey/process.py
+++ b/survey/process.py
@@ -67,14 +67,24 @@ def process_main(sys_args):
 
 			url_occ_dict = update_url_occurrences(url_occ_dict, urls)
 			url_hash_dict = update_url_hashes(url_hash_dict, res)
-				
+
+							
 	fmt = '%24s: urls=%.3f hashes=%.3f fails=%02d'
-	print fmt % (host, jaccard(url_sets), jaccard(hash_sets), fail_count)
+	print fmt % (host, jaccard(url_sets), jaccard(hash_sets), fail_count),
+	print "\n","="*80,"\n",
+
+	print "Inconsistent URLs:"
 	inconsistent_url_dict = extract_inconsistent_urls(url_occ_dict,n_trials,fail_count)
 	print_dict(inconsistent_url_dict)
+	print "\n","="*80,"\n",
+
+	print "Inconsistent Resources:"
 	inconsistent_res_dict = extract_inconsistent_resources(url_hash_dict)
 	print_dict(inconsistent_res_dict)
-	#parse_urls(inconsistent_url_dict.keys())
+	print "\n","="*80,"\n",
+
+	print "Parsed Urls:"
+	parse_urls(inconsistent_url_dict.keys())
 	
 
 # Maps any resource URL encountered to # of occurrences across all trials
@@ -153,11 +163,22 @@ def parse_urls(url_list):
 	url_trie = {}
 	for url in url_list:
 		url_trie = urltrie.insert_url(url,url_trie,True)
-	urltrie.print_trie(url_trie,0)
-	urltrie.print_url_netlocs(url_trie)
+	print "Url Trie:"
+	urltrie.print_trie(url_trie)
+
+	compression_level = 2
+	print "\n","="*80
+	print "compressed trie (level",compression_level,"):"
+	compressed_trie = {}
+	compressed_trie = urltrie.get_compressed_trie(url_trie,compression_level)
+	urltrie.print_trie(compressed_trie)
+	#print "\n","All netlocs in trie:"
+	#urltrie.print_url_netlocs(url_trie)
 
 # Simple utility for printing a dictionary in a more readable way
 def print_dict(d):
+	if len(d) == 0:
+		print "Warning: print_dict: dictionary empty"
 	for k,v in sorted(d.items()):
 		print k, ": ", v
 

--- a/survey/process.py
+++ b/survey/process.py
@@ -3,6 +3,9 @@
 import json
 import sys
 import urltrie
+import urltable
+
+sim_thresh = 0.75
 
 def jaccard(sets):
 	if len(sets) == 0:
@@ -83,8 +86,14 @@ def process_main(sys_args):
 	print_dict(inconsistent_res_dict)
 	print "\n","="*80,"\n",
 
-	print "Parsed Urls:"
+	print "Trie-parsed URLs:"
 	parse_urls(inconsistent_url_dict.keys())
+	print "\n","="*80,"\n",
+
+	print "Tabulated URLs:"
+	inconsistent_url_tab = urltable.create_sim_url_tab(inconsistent_url_dict.keys(),
+							   sim_thresh)
+	urltable.print_sim_url_tab(inconsistent_url_tab)
 	
 
 # Maps any resource URL encountered to # of occurrences across all trials

--- a/survey/st.sh
+++ b/survey/st.sh
@@ -2,7 +2,9 @@
 if [ $# -gt 0 ]; then
     targets=$(find results/$1 -name "results.json")
     outfile="resultstats/"$1"-detailed.txt"
+    echo "Processing "$1"..."
     python process.py $targets > $outfile
+    echo "Done"
 else
     echo "Usage; must specify a result directory"
 fi

--- a/survey/st.sh
+++ b/survey/st.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+if [ $# -gt 0 ]; then
+    targets=$(find results/$1 -name "results.json")
+    outfile="resultstats/"$1"-detailed.txt"
+    python process.py $targets > $outfile
+else
+    echo "Usage; must specify a result directory"
+fi
+    

--- a/survey/urltable.py
+++ b/survey/urltable.py
@@ -1,0 +1,153 @@
+"""
+  This file contains the implementation of a different data structure for
+  organizing URLs of resources required by a website.
+
+  Rather than splitting URLs into a hierarchical data structure, URLs that
+  are not sufficiently similar will be stored as unrelated entries, whereas
+  URLs that meet some "similarity threshold" will be stored with some
+  redundancy
+
+  The overall data structure for storing all inconsistent URLs in a page will
+  be a list of a list of dictionaries. The top level list will contain all
+  the sets of similar URLs
+  
+  Each element of that list will be a list of dictionaries representing a set
+  of similar URLs. Each dictionary in that list will be a segment of a split
+  URL. Segments that are the same across all similar URLs will be dictionaries
+  of size 1.
+
+  list of similar URLs
+  -------------------------------------------------------------
+  |* |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |  |
+  -------------------------------------------------------------
+   |
+   |   List of URL parts
+   |   ex. [http://, www, cnzz, mmstat, com, 9, gif, abc=1, rnd=###]
+   |   ----------------------------------------
+   +-->|* |  |  |  |  |  |  |  |  |  |  |  |  |
+       ----------------------------------------
+        |
+        |
+        +-->[] or list of variations in order of appearance
+
+"""
+
+import urlparse
+import helper
+import sys
+
+wild_sym = '##!!##'
+
+# Similarity threshold expressed as a percent of varying elements
+# within a URL
+def create_sim_url_tab(url_list, sim_thresh):
+    sim_url_table = []
+    for url in url_list:
+        insert_url(sim_url_table, url, sim_thresh)
+
+    return sim_url_table
+
+
+def insert_url(sim_url_table, new_url, sim_thresh):
+    new_url_list = split_url(new_url)
+    for i,tab_url in enumerate(sim_url_table):
+        tab_url_list = sorted(tab_url.keys())
+        if check_urls_sim(helper.strip(tab_url_list,1), new_url_list, sim_thresh) == True:
+            #updated_tab_url = update_tab_url(tab_url, new_url_list)
+            update_tab_url(tab_url, new_url_list)
+            #sim_url_table[i] = updated_tab_url
+            return
+    new_tab_url = create_tab_url(new_url_list)
+    sim_url_table.append(new_tab_url)
+    return
+
+# Tab URL keys are tuples of the form (seg #, seg text)
+# values are lists, either empty or containing the list of possible values
+# for the segment among similar URLs
+def update_tab_url(tab_url, new_url_list):
+    tab_url_segs = sorted(tab_url.keys())
+    assert len(tab_url_segs) == len(new_url_list)
+    for i in xrange(0,len(tab_url_segs)):
+        if tab_url_segs[i][1] == wild_sym:
+            if not new_url_list[i] in tab_url[tab_url_segs[i]]:
+                tab_url[tab_url_segs[i]].append(new_url_list[i])
+        elif tab_url_segs[i][1] != new_url_list[i]:
+            old_seg_text = tab_url_segs[i][1]
+            old_seg_num = tab_url_segs[i][0]
+            del(tab_url[tab_url_segs[i]])
+            tab_url[(old_seg_num,wild_sym)] = []
+            tab_url[(old_seg_num,wild_sym)].append(old_seg_text)
+            tab_url[(old_seg_num,wild_sym)].append(new_url_list[i])
+    #return tab_url
+
+
+
+# New table URL is stored as a dictionary
+# Keys are tuples of the form (segment #, segment text)
+# Values are initially empty lists; if value is a variation, segment text
+# will be replaced by wild_sym and value will hold a list of the possible
+# actual values of the segment text
+def create_tab_url(new_url_list):
+    new_tab_url = {}
+    for i,u_seg in enumerate(new_url_list):
+        new_tab_url[(i,u_seg)] = []
+    return new_tab_url
+
+
+def split_url(url):
+    url_list = []
+    scheme,netloc,path,params,query,fragment = urlparse.urlparse(url)
+    netloc_list = netloc.split('.')
+    path_list = path.split('/')
+    params_list = params.split(';')
+    query_list = query.split('&')
+    frag_list = fragment.split('&')
+
+    # TODO: can further split up these subsections later as necessary
+    url_list.append(scheme)
+    url_list.extend(netloc_list) #TODO: queries or params within netloc?
+    url_list.extend(path_list)
+    url_list.extend(params_list)
+    url_list.extend(query_list)
+    url_list.extend(frag_list)
+    url_list = helper.remove_empty_strings(url_list)
+    
+    return url_list
+
+# 2 URLs are similar under a given similarity threshhold if their respective
+# lists have a % of differences <= sim_thresh
+def check_urls_sim(tab_url, new_url, sim_thresh):
+    assert (sim_thresh >= 0)
+    assert (sim_thresh <= 1)
+    if len(tab_url) != len(new_url):
+        return False
+    else:
+        diff_count = 0
+        total_len = len(tab_url)
+        for i in xrange(0,len(tab_url)):
+            if tab_url[i] != new_url[i]: #&& tab_url[i] != wild_sym:
+                diff_count += 1
+            if (float(diff_count)/total_len) > (1-sim_thresh):
+                return False
+        return True
+        
+def print_sim_url_tab(sim_url_tab):
+    print '-'*40
+    for tab_url in sim_url_tab:
+        # Reconstruct url using url_unparse
+        # Probably have to add some metadata to be able to reconstruct it
+        # for now, just dump it with a generic separator
+        for (seg_n,seg_text) in sorted(tab_url.keys()):
+            if seg_text == wild_sym:
+                print seg_text,":",seg_n,"::",
+            else:
+                print seg_text,'::',
+        print
+        for (seg_n,seg_text) in sorted(tab_url.keys()):
+            variation_list = tab_url[(seg_n,seg_text)]
+            if len(variation_list) > 0:
+                print seg_n,
+                for seg_variation in variation_list:
+                    print "\t",seg_variation
+        print '-'*40
+        

--- a/survey/urltable.py
+++ b/survey/urltable.py
@@ -174,7 +174,7 @@ def print_sim_url_tab(sim_url_tab):
         for (seg_n,seg_text) in sorted(tab_url.keys()):
             variation_list = tab_url[(seg_n,seg_text)]
             if len(variation_list) > 0:
-                print seg_n,
+                print "Seg",seg_n,
                 for seg_variation in variation_list:
                     print "\t",seg_variation
         print '-'*40

--- a/survey/urltrie.py
+++ b/survey/urltrie.py
@@ -71,24 +71,67 @@ def insert_hierarchical_list(top,rest,trie):
             trie[top] = insert_hierarchical_list(next_top, rest, next_trie)
     return trie
 
-def print_trie(trie, level):
+def print_trie(trie):
+    print_trie_h(trie,0)
+
+def print_trie_h(trie, level):
     if isinstance(trie, (int, long)):
         print " "*level,"occurrences: ",trie
     else:
         for k in trie:
             print " "*level,k,":"
-            print_trie(trie[k],level+1)
+            print_trie_h(trie[k],level+1)
 
 def print_url_netlocs(trie):
     for scheme,netlocs in trie.items():
         for netloc in netlocs:
             print netloc
 
+def get_compressed_trie(trie, depth):
+    compressed_trie = {}
+    # Necessary if depth > depth of trie
+    if isinstance(trie, (int, long)):
+        return trie
+    elif depth == 0:
+        for t in trie:
+            compressed_trie[t] = get_num_elts(trie[t])
+        return compressed_trie
+    else:
+        for t in trie:
+            compressed_trie[t] = get_compressed_trie(trie[t], depth-1)
+        return compressed_trie
+        
 
-#test_trie = {"a":{"b":{"c":1},"g":{"h":3}},"d":{"e":{"f":2}}}
-#print_trie(test_trie,0)
+def get_num_elts(trie):
+    if isinstance(trie, (int, long)):
+        return trie
+    else:
+        level_sum = 0
+        for t in trie:
+            level_sum += get_num_elts(trie[t])
+        return level_sum
 
+def remove_empty_strings(l):
+    return filter(lambda elt: elt != '', l)
+    
 """
+test_trie = {"a":{"b":{"c":1},"g":{"h":3}},"d":{"e":{"f":2}}}
+print_trie(test_trie)
+print "# elements:",(get_num_elts(test_trie))
+compressed_test_trie_0 = get_compressed_trie(test_trie, 0)
+compressed_test_trie_1 = get_compressed_trie(test_trie, 1)
+compressed_test_trie_2 = get_compressed_trie(test_trie, 2)
+compressed_test_trie_99 = get_compressed_trie(test_trie, 99)
+print "Compressed at level 0"
+print_trie(compressed_test_trie_0)
+print "Compressed at level 1"
+print_trie(compressed_test_trie_1)
+print "Compressed at level 2"
+print_trie(compressed_test_trie_2)
+print "Compressed at level 99"
+print_trie(compressed_test_trie_99)
+
+
 l1 = ["a","b","c","d"]
 l2 = ["e","f","g","h"]
 l3 = ["a","b","c","e"]
@@ -97,12 +140,17 @@ trie = insert_hierarchical_list(l1.pop(0),l1,{})
 trie2 = insert_hierarchical_list(l2.pop(0),l2,trie)
 trie3 = insert_hierarchical_list(l3.pop(0),l3,trie2)
 trie4 = insert_hierarchical_list(l4.pop(0),l4,trie3)
-print_trie(trie4,0)
+print "\n","="*80
+print_trie(trie4)
+print "# elements:",(get_num_elts(trie4))
+compressed_trie4 = get_compressed_trie(trie4, 1)
+print "Compressed at level 1"
+print_trie(compressed_trie4)
 
 
 test_url = "https://google.com/path/;params"
 test_url2 = "https://google.com/path/;params2"
 url_trie = insert_url(test_url,{})
 url_trie = insert_url(test_url2,url_trie)
-print_trie(url_trie,0)
+print_trie(url_trie)
 """

--- a/survey/urltrie.py
+++ b/survey/urltrie.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+
+# This is the implementation of a data structure specialized for storing
+# a URL according to its structure
+
+# For now, it splits up the URL in accordance with the standard 6 parts
+# returned by the urlparse.urlparse function from Python 2.0.x
+# It has 6 levels: scheme, netloc, path, params, query, fragment
+# although it could potentially be expanded to separate dfifferent params
+# by semicolon or path elements by "/" into their own levels
+# The leaf of each path represents a # of occurrences of the particular URL
+
+# For example, the two URLs
+# https://youtube.com/video1/;param1=p1;param2=p2
+# https://youtube.com/video2/;param1=p1;param2=p2
+
+# would be stored:
+
+#			https
+#			  |
+#		     youtube.com
+#		        /   \
+#		   video1   video2
+#		      /       \
+#   param1=p1;param2=p2;      param1=p1;param2=p2;
+
+import urlparse
+import sys
+
+def insert_url(url,trie,split_sections):
+    scheme,netloc,path,params,query,fragment = urlparse.urlparse(url)
+
+    path_list = [path]
+    param_list = [params]
+
+    # TODO: improve this
+    # Ultimately should be able to split up every element except scheme, potentially
+    #if split_sections == True:
+    #    path_list = path.split('/')
+    #    param_list = params.split(';')
+        
+    url_list = [scheme,netloc]
+    url_list.extend(path_list)
+    url_list.extend(param_list)
+    url_list.append(query)
+    url_list.append(fragment)
+
+    top = url_list.pop(0)
+    trie = insert_hierarchical_list(top,url_list,trie)
+    return trie
+
+def insert_hierarchical_list(top,rest,trie):
+    if top in trie:
+        # at the bottom of a structured list; this corresponds to a complete
+        # url and therefore the final level is a value representing # of occur-
+        # rences
+        if len(rest) == 0:
+            trie[top] += 1
+        else:
+            next_trie = trie[top]
+            next_top = rest[0]
+            assert rest.pop(0) == next_top
+            trie[top] = insert_hierarchical_list(next_top, rest, next_trie)
+    else:
+        if len(rest) == 0:
+            trie[top] = 1
+        else:
+            next_trie = {}
+            next_top = rest[0]
+            assert rest.pop(0) == next_top
+            trie[top] = insert_hierarchical_list(next_top, rest, next_trie)
+    return trie
+
+def print_trie(trie, level):
+    if isinstance(trie, (int, long)):
+        print " "*level,"occurrences: ",trie
+    else:
+        for k in trie:
+            print " "*level,k,":"
+            print_trie(trie[k],level+1)
+
+def print_url_netlocs(trie):
+    for scheme,netlocs in trie.items():
+        for netloc in netlocs:
+            print netloc
+
+
+#test_trie = {"a":{"b":{"c":1},"g":{"h":3}},"d":{"e":{"f":2}}}
+#print_trie(test_trie,0)
+
+"""
+l1 = ["a","b","c","d"]
+l2 = ["e","f","g","h"]
+l3 = ["a","b","c","e"]
+l4 = ["a","b","c","d"]
+trie = insert_hierarchical_list(l1.pop(0),l1,{})
+trie2 = insert_hierarchical_list(l2.pop(0),l2,trie)
+trie3 = insert_hierarchical_list(l3.pop(0),l3,trie2)
+trie4 = insert_hierarchical_list(l4.pop(0),l4,trie3)
+print_trie(trie4,0)
+
+
+test_url = "https://google.com/path/;params"
+test_url2 = "https://google.com/path/;params2"
+url_trie = insert_url(test_url,{})
+url_trie = insert_url(test_url2,url_trie)
+print_trie(url_trie,0)
+"""

--- a/survey/urltrie.py
+++ b/survey/urltrie.py
@@ -25,6 +25,7 @@
 #   param1=p1;param2=p2;      param1=p1;param2=p2;
 
 import urlparse
+import helper
 import sys
 
 def insert_url(url,trie,split_sections):
@@ -111,8 +112,6 @@ def get_num_elts(trie):
             level_sum += get_num_elts(trie[t])
         return level_sum
 
-def remove_empty_strings(l):
-    return filter(lambda elt: elt != '', l)
     
 """
 test_trie = {"a":{"b":{"c":1},"g":{"h":3}},"d":{"e":{"f":2}}}


### PR DESCRIPTION
Process.py now does an additional type of processing using a new data structure which I implemented in urltable.py. The table stores sets of URLs it determines to be similar and reports the fine-grained differences in a more intuitive way than the "url tries." 

To see the new output produced specifically by the urltable, run dprocess.sh. dprocess.sh (detailed-process.sh) will process all of the sites in the results directory and store the processing results in "resultstats/<site-name>-detailed.txt". To then see the URL table output, search for "Tabulated URLs" in the text document. Some of the detailed documents are enormous.

The similarity threshhold definitely still needs to be refined and I think there might be more splitting of URLs that can be done in some cases to further isolate differences between similar URLs but I hope this is a good start and is more readable than the tries.

@bford
